### PR TITLE
Move screenshots to top of README for better visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,15 @@
 
 *The most elegant solution to refresh your Windsurf IDE with a single click*
 
+### 🎨 Screenshots
+
+![Windsurf Reset Application](show.png)
+
+*Windsurf Reset - Clean and Modern Interface*
+
 </div>
+
+---
 
 ### 🎯 Key Features
 
@@ -271,14 +279,6 @@
 
 <div align="center">
 
-### 🎨 Screenshots
-
-![Windsurf Reset Application](show.png)
-
-*Windsurf Reset - Clean and Modern Interface*
-
----
-
 ### 💬 FAQ
 
 <details>
@@ -354,7 +354,15 @@ Contributions are welcome! If you modify this software, your changes must be ope
 
 *一键刷新 Windsurf IDE 的最优雅解决方案*
 
+### 🎨 界面预览
+
+![Windsurf Reset 应用程序](show.png)
+
+*Windsurf Reset - 简洁现代的界面*
+
 </div>
+
+---
 
 ### 🎯 核心功能
 
@@ -596,14 +604,6 @@ Contributions are welcome! If you modify this software, your changes must be ope
 
 <div align="center">
 
-### 🎨 界面预览
-
-![Windsurf Reset 应用程序](show.png)
-
-*Windsurf Reset - 简洁现代的界面*
-
----
-
 ### 💬 常见问题
 
 <details>
@@ -679,7 +679,15 @@ Contributions are welcome! If you modify this software, your changes must be ope
 
 *Die eleganteste Lösung, um Ihre Windsurf IDE mit einem Klick zu aktualisieren*
 
+### 🎨 Screenshots
+
+![Windsurf Reset Anwendung](show.png)
+
+*Windsurf Reset - Saubere und Moderne Oberfläche*
+
 </div>
+
+---
 
 ### 🎯 Hauptfunktionen
 
@@ -920,14 +928,6 @@ Contributions are welcome! If you modify this software, your changes must be ope
 ---
 
 <div align="center">
-
-### 🎨 Screenshots
-
-![Windsurf Reset Anwendung](show.png)
-
-*Windsurf Reset - Saubere und Moderne Oberfläche*
-
----
 
 ### 💬 FAQ
 


### PR DESCRIPTION
- Relocate application screenshots to the beginning of each language section
- Place screenshots after introduction, before Key Features
- Improve user engagement by showing the app interface upfront
- Applies to English, Chinese, and German sections

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved application screenshots to the top of each README language section (English, Chinese, German), placed after the introduction and before Key Features. Improves visibility and engagement by showing the interface upfront and removes duplicate screenshot sections later in the document.

<sup>Written for commit a8a0a11f8712a9babb6101567f8144ae9dad2d6c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

